### PR TITLE
Pathfinding setting

### DIFF
--- a/src/Controllers/XummConfigurationController.cs
+++ b/src/Controllers/XummConfigurationController.cs
@@ -78,6 +78,7 @@ public class XummConfigurationController : BasePaymentController
             XrplPaymentDestinationTag = settings.XrplPaymentDestinationTag?.ToString(),
             XrplRefundDestinationTag = settings.XrplRefundDestinationTag?.ToString(),
             XrplCurrencyAndIssuer = IssuerCurrencyExtensions.GetCurrencyIdentifier(settings.XrplIssuer, settings.XrplCurrency),
+            XrplPathfinding = settings.XrplPathfinding,
             ValidXrplAddress = settings.XrplAddress.IsAccountAddress(),
             ValidApiCredentials = pong?.Pong ?? false,
             WebhookUrl = await _xummService.GetWebhookUrlAsync(storeScope),
@@ -94,6 +95,7 @@ public class XummConfigurationController : BasePaymentController
             model.XrplPaymentDestinationTag_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.XrplPaymentDestinationTag, storeScope);
             model.XrplRefundDestinationTag_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.XrplRefundDestinationTag, storeScope);
             model.XrplCurrencyAndIssuer_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.XrplCurrency, storeScope);
+            model.XrplPathfinding_OverrideForStore = await _settingService.SettingExistsAsync(settings, x => x.XrplPathfinding, storeScope);
         }
 
         if (model.ValidApiCredentials)
@@ -241,6 +243,9 @@ public class XummConfigurationController : BasePaymentController
 
         settings.XrplCurrency = currency;
         await _settingService.SaveSettingOverridablePerStoreAsync(settings, setting => setting.XrplCurrency, model.XrplCurrencyAndIssuer_OverrideForStore, storeScope, clearCache: false);
+
+        settings.XrplPathfinding = model.XrplPathfinding;
+        await _settingService.SaveSettingOverridablePerStoreAsync(settings, setting => setting.XrplPathfinding, model.XrplPathfinding_OverrideForStore, storeScope, clearCache: false);
 
         await _settingService.ClearCacheAsync();
 

--- a/src/Extensions/TransactionExtensions.cs
+++ b/src/Extensions/TransactionExtensions.cs
@@ -7,6 +7,22 @@ namespace Nop.Plugin.Payments.Xumm.Extensions;
 
 internal static class TransactionExtensions
 {
+    internal static bool IsEqualTo(this XummTransactionBalanceChanges value1, XummTransactionBalanceChanges value2)
+    {
+        if (string.IsNullOrWhiteSpace(value1.CounterParty) && string.IsNullOrWhiteSpace(value2.CounterParty))
+        {
+            // XRP
+            return true;
+        }
+        
+        if (!value1.CounterParty?.Equals(value2.CounterParty) ?? false)
+        {
+            return false;
+        }
+
+        return value1.Currency.Equals(value2.Currency);
+    }
+
     internal static List<XummTransactionBalanceChanges> GetReceivedBalanceChanges(this XummTransaction xummTransaction, string account)
     {
         return xummTransaction.GetBalanceChanges(account, false);

--- a/src/Models/ConfigurationModel.cs
+++ b/src/Models/ConfigurationModel.cs
@@ -76,6 +76,14 @@ public record ConfigurationModel : BaseNopModel
 
     public bool XrplCurrencyAndIssuer_OverrideForStore { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow pathfinding on the XRPL
+    /// </summary>
+    [NopResourceDisplayName("Plugins.Payments.Xumm.Fields.XrplPathfinding")]
+    public bool XrplPathfinding { get; set; }
+
+    public bool XrplPathfinding_OverrideForStore { get; set; }
+
     public IList<SelectListItem> XrplCurrencies { get; set; } = new List<SelectListItem>();
 
     public bool TrustSetRequired { get; set; }

--- a/src/Services/XummService.cs
+++ b/src/Services/XummService.cs
@@ -355,9 +355,11 @@ public class XummService : IXummService
         {
             ReturnUrl = new XummPayloadReturnUrl
             {
-                Web = returnUrl
+                Web = returnUrl,
+                App = returnUrl
             }
         };
+
         payload.CustomMeta = new XummPayloadCustomMeta
         {
             Instruction = instruction,

--- a/src/Views/Configure.cshtml
+++ b/src/Views/Configure.cshtml
@@ -122,6 +122,16 @@
                             <span asp-validation-for="XrplRefundDestinationTag"></span>
                         </div>
                     </div>
+                    <div class="form-group row">
+                        <div class="col-md-3">
+                            <nop-override-store-checkbox asp-for="XrplPathfinding_OverrideForStore" asp-input="XrplPathfinding" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+                            <nop-label asp-for="XrplPathfinding" />
+                        </div>
+                        <div class="col-md-6">
+                            <nop-editor asp-for="XrplPathfinding" />
+                            <span asp-validation-for="XrplPathfinding"></span>
+                        </div>
+                    </div>
                 }
                 <div class="form-group row">
                     <div class="col-md-6 offset-md-3">

--- a/src/XummDefaults.cs
+++ b/src/XummDefaults.cs
@@ -80,11 +80,6 @@ public static class XummDefaults
         /// <seealso href="https://xrpl.org/transaction-results.html"/>
         /// </summary>
         public static string SuccessTransactionResultPrefix => "tes";
-
-        /// <summary>
-        /// Enable pathfinding so the user can select the asset to send to deliver the requested asset amount.
-        /// </summary>
-        public static bool PathfindingEnabled = true;
     }
 
     public static class Mail

--- a/src/XummPaymentMethod.cs
+++ b/src/XummPaymentMethod.cs
@@ -360,6 +360,8 @@ public class XummPaymentMethod : BasePlugin, IPaymentMethod
             ["Plugins.Payments.Xumm.Fields.XrplCurrency.TrustLineHeader"] = "Others",
             ["Plugins.Payments.Xumm.Fields.XrplCurrency.TrustLineSet"] = "Trust line for currency {0} of issuer {1} has been set.",
             ["Plugins.Payments.Xumm.Fields.XrplCurrency.MissingPrimaryStoreCurrency"] = "Store currency {0} has to exist and set as Primary Store Currency at Configuration > Currencies.",
+            ["Plugins.Payments.Xumm.Fields.XrplPathfinding"] = "Pathfinding",
+            ["Plugins.Payments.Xumm.Fields.XrplPathfinding.Hint"] = "Enable pathfinding to allow payments of any token on the XRPL and still receive your configured currency.",
             ["Plugins.Payments.Xumm.Fields.AdditionalFee"] = "Additional fee",
             ["Plugins.Payments.Xumm.Fields.AdditionalFee.Hint"] = "Enter additional fee to charge your customers.",
             ["Plugins.Payments.Xumm.Fields.AdditionalFee.ShouldBeGreaterThanOrEqualZero"] = "The additional fee should be greater than or equal 0",

--- a/src/XummPaymentSettings.cs
+++ b/src/XummPaymentSettings.cs
@@ -45,6 +45,11 @@ public class XummPaymentSettings : ISettings
     public string XrplIssuer { get; set; }
 
     /// <summary>
+    /// Pay with any token available on the XRPL with pathfinding enabled
+    /// </summary>
+    public bool XrplPathfinding { get; set; }
+
+    /// <summary>
     /// Gets or sets a additional fee
     /// </summary>
     public decimal AdditionalFee { get; set; }


### PR DESCRIPTION
- Added a checkbox to the configuration page to enable or disable pathfinding.
- Removed the use of path find on refunds to the same currency as the shop.